### PR TITLE
fix: update subcommand help to use dynamic command name

### DIFF
--- a/generator/src/cmd.rs
+++ b/generator/src/cmd.rs
@@ -93,7 +93,7 @@ pub(crate) fn generate(endpoints: Vec<endpoint::Endpoint>) -> Tokens {
                             }
                         }
                     } else {
-                        if let Some(namespace_command) = cmd.find_subcommand_mut("core") {
+                        if let Some(namespace_command) = cmd.find_subcommand_mut(command) {
                             let _ = namespace_command.print_help();
                         }
                         println!();


### PR DESCRIPTION
Instead of static "core".
Obviously improve the overall experience.